### PR TITLE
Extending the eye stop-gap function

### DIFF
--- a/src/QuantumInfo.jl
+++ b/src/QuantumInfo.jl
@@ -7,6 +7,8 @@ eye(m::AbstractMatrix) = Matrix{eltype(m)}(I, size(m))
 
 eye(n::Integer) = Matrix{Float64}(I, (n, n))
 
+eye(T::DataType, n::Integer) = Matrix{T}(I, (n, n))
+
 include("basics.jl")
 include("open-systems.jl")
 


### PR DESCRIPTION
Some code dependencies pass a data type to the old `eye` function.  While we're using it as a stop-gap, might as well extend it.