### PR TITLE
scale! is now depricated

### DIFF
--- a/src/QuantumInfo.jl
+++ b/src/QuantumInfo.jl
@@ -1,6 +1,6 @@
 module QuantumInfo
 using Cliffords
-using LinearAlgebra: I, norm, tr, eigvals, eigen, svdvals
+using LinearAlgebra: I, norm, tr, eigvals, eigen, svdvals, lmul!
 
 # As a stopgap, reintroduce the old `eye`.
 eye(m::AbstractMatrix) = Matrix{eltype(m)}(I, size(m))

--- a/src/basics.jl
+++ b/src/basics.jl
@@ -112,9 +112,20 @@ trnormalize( m::AbstractMatrix ) = m/trnorm(m)
 Normalizes a matrix with respect to the trace norm (Schatten 1
 norm) in place.
 """
-function trnormalize!( m::AbstractMatrix )
+function trnormalize!( m::AbstractMatrix{T} ) where T <: ComplexF64
+    n = convert(ComplexF64, trnorm(m))
+    lmul!(1/n,m)
+end
+
+function trnormalize!( m::AbstractMatrix{T} ) where T <: Float64
     n = trnorm(m)
-    scale!(m,1/n)
+    lmul!(1/n,m)
+end
+
+function trnormalize!( m::AbstractMatrix{T} ) where T <: Int64
+    n = convert(Float64, trnorm(m))
+    m = convert(Array{Float64}, m)
+    lmul!(1/n,m)
 end
 
 """


### PR DESCRIPTION
Fixing with `lmul!` and and multiple dispatch for type stability.  `BLAS.scal!` would be another option but since this is just scalar multiplication I think it's overkill.