### PR TITLE
Support AbstractArray types

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6
+julia 0.7
 Cliffords

--- a/src/basics.jl
+++ b/src/basics.jl
@@ -12,7 +12,7 @@ export ket,
        ispossemidef,
        pauli_decomp
 
-trnorm(M::Matrix) = sum(svdvals(M))
+trnorm(M::AbstractMatrix) = sum(svdvals(M))
 
 """
 `basis_vector(T,i,d)`
@@ -95,7 +95,7 @@ ketbra( i::Int, j::Int, d::Int ) = ket( i, d ) * bra( j, d )
 Computes the rank-1 projector operator corresponding to a given vector. If more than one
 vector is given, the projector into the space spanned by the vectors is computed.
 """
-function projector( v::Vector )
+function projector( v::AbstractVector )
     v*v'/norm(v,2)^2
 end
 
@@ -131,7 +131,7 @@ end
 """
 Computes the partial trace of a matrix `m`.
 """
-function partialtrace( m::Matrix{T}, ds::Vector, dt::Int ) where T
+function partialtrace( m::AbstractMatrix{T}, ds::AbstractVector, dt::Int ) where T
   s = size(m)
   l = length(ds);
   if s[1] != s[2]
@@ -172,7 +172,7 @@ end
 """
 Computes a purification of `rho`
 """
-function purify( rho::Matrix )
+function purify( rho::AbstractMatrix )
   d = size(rho,1)
   (vals,vecs) = eig(rho)
   psi = zeros(eltypeof(rho), d^2)
@@ -200,7 +200,7 @@ Computes the fidelity between two quantum states. By default, the Josza conventi
 is used. The Uhlmann fidelity may be calculated by using the `kind` keyword argument
 with the value `:uhlmann`.
 """
-function fidelity(a::Matrix,b::Matrix;kind=:josza)
+function fidelity(a::AbstractMatrix,b::AbstractMatrix;kind=:josza)
     fu = trnorm(sqrtm(a)*sqrtm(b))
     if kind==:josza
         return fu^2
@@ -209,15 +209,15 @@ function fidelity(a::Matrix,b::Matrix;kind=:josza)
     end
 end
 
-function fidelity(a::Vector,b::Vector;kind=:josza)
+function fidelity(a::AbstractVector,b::AbstractVector;kind=:josza)
     return fidelity(projector(a),projector(b),kind=kind)
 end
 
-function fidelity(a::Vector,b::Matrix;kind=:josza)
+function fidelity(a::AbstractVector,b::AbstractMatrix;kind=:josza)
     return fidelity(projector(a),b,kind=kind)
 end
 
-function fidelity(a::Matrix,b::Vector;kind=:josza)
+function fidelity(a::AbstractMatrix,b::AbstractVector;kind=:josza)
     return fidelity(b,a,kind=kind)
 end
 
@@ -236,11 +236,11 @@ end
 #       avg2entfidelity()
 #       ent2avgfidelity()
 
-# fidelity Vector Vector
-# fidelity Vector Matrix
-# fidelity Matrix Matrix
-# superfidelity Matrix Matrix
-# subfidelity Matrix Matrix
+# fidelity AbstractVector AbstractVector
+# fidelity AbstractVector AbstractMatrix
+# fidelity AbstractMatrix AbstractMatrix
+# superfidelity AbstractMatrix AbstractMatrix
+# subfidelity AbstractMatrix AbstractMatrix
 
 """
 Tests if a matrix is positive semidefinite within a given tolerance.
@@ -254,7 +254,7 @@ end
 """
 Decompose a density matrix into Pauli operators with a given cutoff.
 """
-function pauli_decomp(ρ::Matrix, cutoff=1e-3)
+function pauli_decomp(ρ::AbstractMatrix, cutoff=1e-3)
     r = Dict{Pauli,Float64}()
     d2 = size(ρ, 1)
     d = round(Int, sqrt(d2))

--- a/src/open-systems.jl
+++ b/src/open-systems.jl
@@ -24,33 +24,33 @@ export mat,
        isliouvillian,
        nearestu
 
-mat( v::Vector, r=round(Int,sqrt(length(v))), c=round(Int,sqrt(length(v))) ) = reshape( v, r, c )
+mat(v::AbstractVector, r=round(Int,sqrt(length(v))), c=round(Int,sqrt(length(v))) ) = reshape( v, r, c )
 liou( left::AbstractMatrix, right::AbstractMatrix )  = kron( transpose(right), left )
 liou( m::AbstractMatrix ) = kron( conj(m), m )
 
-function choi_liou_involution( r::Matrix )
+function choi_liou_involution( r::AbstractMatrix )
   d = round(Int, sqrt(size(r,1)) )
   rl = reshape( r, (d, d, d, d) )
   rl = permutedims( rl, [1,3,2,4] )
   reshape( rl, size(r) )
 end
 
-function swap_involution( r::Matrix )
+function swap_involution( r::AbstractMatrix )
   d = round(Int, sqrt(size(r,1)) )
   rl = reshape( r, (d, d, d, d) )
   rl = permutedims( rl, [3,4,1,2] )
   reshape( rl, size(r) )
 end
 
-function choi2liou( r::Matrix  )
+function choi2liou( r::AbstractMatrix  )
   sqrt(size(r,1))*choi_liou_involution( r )
 end
 
-function liou2choi( r::Matrix )
+function liou2choi( r::AbstractMatrix )
   choi_liou_involution( r )/sqrt(size(r,1))
 end
 
-function choi2kraus( r::Matrix  )
+function choi2kraus( r::AbstractMatrix  )
     r = eigen( sqrt(size(r,1))*r )
     vals, vecs = (r.values, r.vectors)
     #vals = eigvals( sqrt(size(r,1))*r )
@@ -61,7 +61,7 @@ function choi2kraus( r::Matrix  )
     kraus_ops
 end
 
-function choi2stinespring( r::Matrix  )
+function choi2stinespring( r::AbstractMatrix  )
   r = eigen( Hermitian(sqrt(size(r,1))*r) ) # we are assuming Hermiticity-preserving maps
   vals, vecs = (r.values, r.vectors)
     #vals = eigvals( sqrt(size(r,1))*r )
@@ -75,11 +75,11 @@ function choi2stinespring( r::Matrix  )
   return sum(A_ops),sum(B_ops)
 end
 
-function liou2stinespring( r::Matrix )
+function liou2stinespring( r::AbstractMatrix )
   return r |> liou2choi |> choi2stinespring
 end
 
-function kraus2liou( k::Vector )
+function kraus2liou( k::AbstractVector )
   l = zeros(eltype(k[1]),map(x->x^2,size(k[1])))
   for i in 1:length(k)
     l = l + liou(k[i],k[i]')
@@ -87,11 +87,11 @@ function kraus2liou( k::Vector )
   l
 end
 
-function liou2kraus( l::Matrix )
+function liou2kraus( l::AbstractMatrix )
   choi2kraus( liou2choi( l ) )
 end
 
-function kraus2choi( k::Vector )
+function kraus2choi( k::AbstractVector )
   c = zeros(eltype(k[1]),map(x->x^2,size(k[1])))
   for i in 1:length(k)
     c = c + vec(k[i])*vec(k[i])'
@@ -100,15 +100,15 @@ function kraus2choi( k::Vector )
 end
 
 # TODO: Add support for sparse matrices
-function dissipator( a::Matrix )
+function dissipator( a::AbstractMatrix )
   liou(a,a') - 1/2 * liou(a'*a, eye(a)) - 1/2 * liou(eye(a),a'*a)
 end
 
-function hamiltonian( h::Matrix )
+function hamiltonian( h::AbstractMatrix )
   -1im * ( liou(h,eye(h)) - liou(eye(h),h) )
 end
 
-function pauliliou2liou( m::Matrix )
+function pauliliou2liou( m::AbstractMatrix )
   if size(m,1) != size(m,2)
     error("Only square matrices supported")
   elseif size(m,1) != 4^(floor(log2(size(m,1))/2))
@@ -125,7 +125,7 @@ function pauliliou2liou( m::Matrix )
   res
 end
 
-function liou2pauliliou( m::Matrix )
+function liou2pauliliou( m::AbstractMatrix )
   if size(m,1) != size(m,2)
     error("Only square matrices supported")
   elseif size(m,1) != 4^(floor(log2(size(m,1))/2))
@@ -159,7 +159,7 @@ Given a superoperator `j` in a Liouville representation, `unitalproj`
 extracts the closest superoperator (in Frobenius norm) that is
 unital. The result may not be completely positive.
 """
-function unitalproj( m::Matrix )
+function unitalproj( m::AbstractMatrix )
   d2 = size(m,1)
   d  = round(Int,sqrt(d2))
   id = projector(normalize(vec(eye(d))))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,11 @@
 using QuantumInfo
 using Test
 
+using LinearAlgebra: Diagonal
 import LinearAlgebra
 import QuantumInfo.eye
 
-@testset "partial trace" begin
+@time @testset "partial trace" begin
     for i=1:100
         da = round(Int,round(rand()*10))+1
         db = round(Int,round(rand()*10))+1
@@ -15,46 +16,55 @@ import QuantumInfo.eye
     end
 end
 
-@testset "representation conversion" begin
-    id_choi = 1/2 .* [1 0 0 1;0 0 0 0;0 0 0 0;1 0 0 1];
-    deph_choi = 1/2 .* [1 0 0 0.99;0 0 0 0;0 0 0 0;0.99 0 0 1];
-    deph_liou = [1 0 0 0;0 0.99 0 0;0 0 0.99 0;0 0 0 1];
+alteye(m::AbstractMatrix) = Diagonal(ones(eltype(m), size(m, 1)))
+alteye(n::Integer) = Diagonal(ones(n))
+alteye(T::DataType, n::Integer) = Diagonal(ones(T, n))
 
-    # Kraus operators for a dephasing channel
-    ρ = 0.01;
-    M_0 = sqrt(1-ρ)*eye(2);
-    M_1 = sqrt(ρ)*Matrix{ComplexF64}([1.0 0.0; 0.0 0.0]);
-    M_2 = sqrt(ρ)*Matrix{ComplexF64}([0.0 0.0;0.0 1.0]);
+for eyesym in (:eye, :alteye)
+    println("identity matrix is $(string(eyesym))")
+    @eval begin
+        @time @testset "representation conversion" begin
+            id_choi = 1/2 .* [1 0 0 1;0 0 0 0;0 0 0 0;1 0 0 1];
+            deph_choi = 1/2 .* [1 0 0 0.99;0 0 0 0;0 0 0 0;0.99 0 0 1];
+            deph_liou = [1 0 0 0;0 0.99 0 0;0 0 0.99 0;0 0 0 1];
 
-    @test liou(eye(2),eye(2)) == eye(4)
-    @test liou(eye(2)) == liou(eye(2),eye(2))
-    @test mat(vec(eye(2))) == eye(2)
-    @test mat([1,2,3,4]) == [1 3;2 4]
-    @test vec([1 2; 3 4]) == [1,3,2,4]
+            # Kraus operators for a dephasing channel
+            ρ = 0.01;
+            M_0 = sqrt(1-ρ)*($eyesym)(2);
+            M_1 = sqrt(ρ)*Matrix{ComplexF64}([1.0 0.0; 0.0 0.0]);
+            M_2 = sqrt(ρ)*Matrix{ComplexF64}([0.0 0.0;0.0 1.0]);
 
-    @test choi_liou_involution(choi_liou_involution(eye(4)))==eye(4)
+            @test liou(($eyesym)(2),($eyesym)(2)) == ($eyesym)(4)
+            @test liou(($eyesym)(2)) == liou(($eyesym)(2),($eyesym)(2))
+            @test mat(vec(($eyesym)(2))) == ($eyesym)(2)
+            @test mat([1,2,3,4]) == [1 3;2 4]
+            @test vec([1 2; 3 4]) == [1,3,2,4]
 
-    @test isapprox(choi2liou(id_choi),eye(4))
-    @test isapprox(liou2choi(eye(4)),id_choi)
-    @test isapprox(choi2kraus(id_choi),Matrix{ComplexF64}[zeros(2,2), zeros(2,2), zeros(2,2), eye(2)],atol=1e-7)
-    @test isapprox(kraus2liou(Matrix{ComplexF64}[eye(2)]),eye(4))
-    @test isapprox(liou2kraus(eye(4)),Matrix{ComplexF64}[zeros(2,2), zeros(2,2), zeros(2,2), eye(2)],atol=1e-7)
-    @test isapprox(kraus2choi(Matrix{ComplexF64}[eye(2)]),id_choi)
+            @test choi_liou_involution(choi_liou_involution(($eyesym)(4)))==($eyesym)(4)
 
-    @test isapprox(kraus2choi([M_0, M_1, M_2]),deph_choi)
-    @test isapprox(kraus2liou([M_0, M_1, M_2]),deph_liou)
+            @test isapprox(choi2liou(id_choi),($eyesym)(4))
+            @test isapprox(liou2choi(($eyesym)(4)),id_choi)
+            @test isapprox(choi2kraus(id_choi),Matrix{ComplexF64}[zeros(2,2), zeros(2,2), zeros(2,2), ($eyesym)(2)],atol=1e-7)
+            @test isapprox(kraus2liou(Matrix{ComplexF64}[($eyesym)(2)]),($eyesym)(4))
+            @test isapprox(liou2kraus(($eyesym)(4)),Matrix{ComplexF64}[zeros(2,2), zeros(2,2), zeros(2,2), ($eyesym)(2)],atol=1e-7)
+            @test isapprox(kraus2choi(Matrix{ComplexF64}[($eyesym)(2)]),id_choi)
 
-    @test isapprox(liou2pauliliou(eye(4)), eye(4))
-    @test isapprox(pauliliou2liou(eye(4)), eye(4))
+            @test isapprox(kraus2choi([M_0, M_1, M_2]),deph_choi)
+            @test isapprox(kraus2liou([M_0, M_1, M_2]),deph_liou)
+
+            @test isapprox(liou2pauliliou(($eyesym)(4)), ($eyesym)(4))
+            @test isapprox(pauliliou2liou(($eyesym)(4)), ($eyesym)(4))
+        end
+    end
 end
 
-@testset "depolarization" begin
+@time @testset "depolarization" begin
     @test isapprox(depol(2),projector(vec(eye(2))),atol=1e-15)
     @test isapprox(depol(2),depol(2,1.))
     @test isapprox(depol(2,0.),eye(4),atol=1e-15)
 end
 
-@testset "density matrix properties" begin
+@time @testset "density matrix properties" begin
   for i=1:100
     rrho = partialtrace(projector(randn(3^3)+1im*randn(3^3)),[3,9],2)
     @test isapprox(LinearAlgebra.tr(rrho),1.)


### PR DESCRIPTION
Replace `Matrix` and `Vector` by `AbstractMatrix` and `AbstractVector` in
function signatures.

The modified signatures are tested by repeating one of the testsets
with `eye` replaced by a functionally-equivalent `alteye`. I have also
added `@time` macros before the test sets. This is a good way to spot
gross efficiency regressions. The timing for `alteye` is faster than
that for `eye`. But, the trial with `eye` comes first, so the majority
of reported time represents jit compilation. In fact, `alteye` is slower,
at least for these tests. But, the main point is to test `AbstractArray`
types.